### PR TITLE
Corregido el fallo que duplicaba elementos en la lista de necesidades

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -101,7 +101,7 @@
 
             var needs = Object.values(snapshot.val()).reverse();
             var needsPreviewContainer = $('#needs-preview');
-            $('#needs-preview.items').remove();
+            $('#needs-preview .items').remove();
             needs.forEach((need) => {
                 needsPreviewContainer.append(buildNeedNode(need));
             });


### PR DESCRIPTION
Cuando se añadía una necesidad aparecían duplicados en la lista de necesidades registradas.